### PR TITLE
Revert "git branch instead of branch name"

### DIFF
--- a/ci/jenkins/Jenkins_steps.groovy
+++ b/ci/jenkins/Jenkins_steps.groovy
@@ -1693,8 +1693,8 @@ def upload_s3(){
           // sh 'echo ${env.MXNET_CI_UNITTEST_ARTIFACT_BUCKET}'
             sh 'touch a.txt'
             // archiveArtifacts 'docs/_build/full_website.tgz'
-            echo env.GIT_BRANCH
-            if (env.GIT_BRANCH == "dummy_master") {
+            echo env.BRANCH_NAME
+            if (env.BRANCH_NAME == "dummy_master") {
               s3Upload(file:'a.txt', bucket:env.MXNET_CI_UNITTEST_ARTIFACT_BUCKET, path:utils.get_git_commit_hash().trim()+"-"+env.BUILD_TAG+"/a.txt")
             }
             sh 'echo done'


### PR DESCRIPTION
This reverts commit b69032263b053f900a6a68a42a1eccfc00d3de92.

## Description ##
(Brief description on what this PR is about)

## Checklist ##
### Essentials ###
Please feel free to remove inapplicable items for your PR.
- [ ] The PR title starts with [MXNET-$JIRA_ID], where $JIRA_ID refers to the relevant [JIRA issue](https://issues.apache.org/jira/projects/MXNET/issues) created (except PRs with tiny changes)
- [ ] Changes are complete (i.e. I finished coding on this PR)
- [ ] All changes have test coverage:
- Unit tests are added for small changes to verify correctness (e.g. adding a new operator)
- Nightly tests are added for complicated/long-running ones (e.g. changing distributed kvstore)
- Build tests will be added for build configuration changes (e.g. adding a new build option with NCCL)
- [ ] Code is well-documented: 
- For user-facing API changes, API doc string has been updated. 
- For new C++ functions in header files, their functionalities and arguments are documented. 
- For new examples, README.md is added to explain the what the example does, the source of the dataset, expected performance on test set and reference to the original paper if applicable
- Check the API doc at http://mxnet-ci-doc.s3-accelerate.dualstack.amazonaws.com/PR-$PR_ID/$BUILD_ID/index.html
- [ ] To the my best knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change

### Changes ###
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)

## Comments ##
- If this change is a backward incompatible change, why must this change be made.
- Interesting edge cases to note here
